### PR TITLE
Add Bangumi & Shikimori support for info edit

### DIFF
--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/Bangumi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/Bangumi.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMOAuth
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import kotlinx.collections.immutable.ImmutableList
 import kotlinx.collections.immutable.toImmutableList
@@ -73,6 +74,10 @@ class Bangumi(id: Long) : BaseTracker(id, "Bangumi") {
 
     override suspend fun search(query: String): List<TrackSearch> {
         return api.search(query)
+    }
+
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
+        return api.getMangaMetadata(track)
     }
 
     override suspend fun refresh(track: Track): Track {

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/BangumiApi.kt
@@ -7,6 +7,9 @@ import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMCollectionResponse
 import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMOAuth
 import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMSearchItem
 import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMSearchResult
+import eu.kanade.tachiyomi.data.track.bangumi.dto.BGMSubject
+import eu.kanade.tachiyomi.data.track.bangumi.dto.Infobox
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.network.GET
 import eu.kanade.tachiyomi.network.POST
@@ -21,6 +24,7 @@ import tachiyomi.core.common.util.lang.withIOContext
 import uy.kohesive.injekt.injectLazy
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import tachiyomi.domain.track.model.Track as DomainTrack
 
 class BangumiApi(
     private val trackId: Long,
@@ -121,6 +125,34 @@ class BangumiApi(
                         track.last_chapter_read = it.epStatus!!.toDouble()
                         track.score = it.rating!!
                         track
+                    }
+            }
+        }
+    }
+
+    suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata {
+        return withIOContext {
+            with(json) {
+                authClient.newCall(GET("${API_URL}/v0/subjects/${track.remoteId}"))
+                    .awaitSuccess()
+                    .parseAs<BGMSubject>()
+                    .let {
+                        TrackMangaMetadata(
+                            remoteId = it.id,
+                            title = it.nameCn,
+                            thumbnailUrl = it.images?.common,
+                            description = it.summary,
+                            authors = it.infobox
+                                .filter { it.key == "作者" }
+                                .filterIsInstance<Infobox.SingleValue>()
+                                .map { it.value }
+                                .joinToString(", "),
+                            artists = it.infobox
+                                .filter { it.key == "插图" }
+                                .filterIsInstance<Infobox.SingleValue>()
+                                .map { it.value }
+                                .joinToString(", "),
+                        )
                     }
             }
         }

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSubject.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/bangumi/dto/BGMSubject.kt
@@ -1,0 +1,62 @@
+package eu.kanade.tachiyomi.data.track.bangumi.dto
+
+import kotlinx.serialization.DeserializationStrategy
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+import kotlinx.serialization.SerializationException
+import kotlinx.serialization.json.JsonArray
+import kotlinx.serialization.json.JsonContentPolymorphicSerializer
+import kotlinx.serialization.json.JsonElement
+import kotlinx.serialization.json.JsonObject
+import kotlinx.serialization.json.JsonPrimitive
+
+@Serializable
+data class BGMSubject(
+    val images: BGMSearchItemCovers?,
+    val summary: String,
+    val name: String,
+    @SerialName("name_cn")
+    val nameCn: String,
+    val infobox: List<Infobox>,
+    val id: Long,
+)
+
+// infobox deserializer and related classes courtesy of
+// https://github.com/Snd-R/komf/blob/4c260a3dcd326a5e1d74ac9662eec8124ab7e461/komf-core/src/commonMain/kotlin/snd/komf/providers/bangumi/model/BangumiSubject.kt#L53-L89
+object InfoBoxSerializer : JsonContentPolymorphicSerializer<Infobox>(Infobox::class) {
+    override fun selectDeserializer(element: JsonElement): DeserializationStrategy<Infobox> {
+        if (element !is JsonObject) throw SerializationException("Expected JsonObject go ${element::class}")
+        val value = element["value"]
+
+        return when (value) {
+            is JsonArray -> Infobox.MultipleValues.serializer()
+            is JsonPrimitive -> Infobox.SingleValue.serializer()
+            else -> throw SerializationException("Unexpected element type ${element::class}")
+        }
+    }
+}
+
+@Serializable(with = InfoBoxSerializer::class)
+sealed interface Infobox {
+    val key: String
+
+    @Serializable
+    class SingleValue(
+        override val key: String,
+        val value: String,
+    ) : Infobox
+
+    @Serializable
+    class MultipleValues(
+        override val key: String,
+        val value: List<InfoboxNestedValue>,
+    ) : Infobox
+}
+
+@Serializable
+data class InfoboxNestedValue(
+    @SerialName("k")
+    val key: String? = null,
+    @SerialName("v")
+    val value: String,
+)

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/Shikimori.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/Shikimori.kt
@@ -6,6 +6,7 @@ import eu.kanade.tachiyomi.R
 import eu.kanade.tachiyomi.data.database.models.Track
 import eu.kanade.tachiyomi.data.track.BaseTracker
 import eu.kanade.tachiyomi.data.track.DeletableTracker
+import eu.kanade.tachiyomi.data.track.model.TrackMangaMetadata
 import eu.kanade.tachiyomi.data.track.model.TrackSearch
 import eu.kanade.tachiyomi.data.track.shikimori.dto.SMOAuth
 import kotlinx.collections.immutable.ImmutableList
@@ -96,6 +97,10 @@ class Shikimori(id: Long) : BaseTracker(id, "Shikimori"), DeletableTracker {
             track.total_chapters = remoteTrack.total_chapters
         } ?: throw Exception("Could not find manga")
         return track
+    }
+
+    override suspend fun getMangaMetadata(track: DomainTrack): TrackMangaMetadata? {
+        return api.getMangaMetadata(track)
     }
 
     override fun getLogo() = R.drawable.ic_tracker_shikimori

--- a/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/dto/SMMetadata.kt
+++ b/app/src/main/java/eu/kanade/tachiyomi/data/track/shikimori/dto/SMMetadata.kt
@@ -1,0 +1,38 @@
+package eu.kanade.tachiyomi.data.track.shikimori.dto
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class SMMetadata(
+    val data: SMMetadataData,
+)
+
+@Serializable
+data class SMMetadataData(
+    val mangas: List<SMMetadataResult>,
+)
+
+@Serializable
+data class SMMetadataResult(
+    val id: String,
+    val name: String,
+    val description: String,
+    val poster: SMMangaPoster,
+    val personRoles: List<SMMangaPersonRoles>,
+)
+
+@Serializable
+data class SMMangaPoster(
+    val originalUrl: String,
+)
+
+@Serializable
+data class SMMangaPersonRoles(
+    val person: SMPerson,
+    val rolesEn: List<String>,
+)
+
+@Serializable
+data class SMPerson(
+    val name: String,
+)


### PR DESCRIPTION
This adds the necessary API calls and DTOs to allow for editing an entry's data to the data from a tracker, specifically adding support for Bangumi and Shikimori.

I'm honestly not sure if this covers all the nullability edge cases since neither Bangumi nor Shikimori have, uhh, _very clear_ documentation on any one field. Although a quick test with a few normal titles did work on both. (Tested Dress-Up Darling, Accel World manga, One Piece). Could probably do with finding some weirder entries and seeing how this code copes with those.